### PR TITLE
README.md: fix COPYING link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Please make sure at least these pass before submitting a PR.
 
 ## License
 
-This project is licensed under the GNU LGPLv2.1 License - see the [COPYING.md](COPYING.md) for details
+This project is licensed under the GNU LGPLv2.1 License - see the [COPYING](COPYING) for details


### PR DESCRIPTION
Change the link to point to the COPYING file in README.md instead of the non-existing COPYING.md.