### PR TITLE
furnace/context.py: bind mount '/etc/resolv.conf' in host network mode

### DIFF
--- a/furnace/config.py
+++ b/furnace/config.py
@@ -17,10 +17,16 @@
 # along with Furnace.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from collections import namedtuple
+
 from pathlib import Path
 
 from .libc import CLONE_NEWPID, CLONE_NEWCGROUP, CLONE_NEWIPC, CLONE_NEWUTS, CLONE_NEWNS, CLONE_NEWNET, \
     MS_NOSUID, MS_NOEXEC, MS_NODEV, MS_RDONLY, MS_STRICTATIME
+
+Mount = namedtuple('Mount', ['destination', 'type', 'source', 'flags', 'options'])
+DeviceNode = namedtuple('DeviceNode', ['name', 'major', 'minor'])
+
 
 HOSTNAME = 'localhost'
 
@@ -34,96 +40,100 @@ NAMESPACES = {
 }
 
 CONTAINER_MOUNTS = [
-    {
-        "destination": Path("/proc"),
-        "type": "proc",
-        "source": "proc"
-    },
-    {
-        "destination": Path("/dev"),
-        "type": "tmpfs",
-        "source": "tmpfs",
-        "flags": MS_NOSUID | MS_STRICTATIME,
-        "options": [
+    Mount(
+        destination=Path("/proc"),
+        type="proc",
+        source="proc",
+        flags=0,
+        options=None,
+    ),
+    Mount(
+        destination=Path("/dev"),
+        type="tmpfs",
+        source="tmpfs",
+        flags=MS_NOSUID | MS_STRICTATIME,
+        options=[
             "mode=755",
-            "size=65536k"
-        ]
-    },
-    {
-        "destination": Path("/dev/pts"),
-        "type": "devpts",
-        "source": "devpts",
-        "flags": MS_NOSUID | MS_NOEXEC,
-        "options": [
+            "size=65536k",
+        ],
+    ),
+    Mount(
+        destination=Path("/dev/pts"),
+        type="devpts",
+        source="devpts",
+        flags=MS_NOSUID | MS_NOEXEC,
+        options=[
             "newinstance",
             "ptmxmode=0666",
             "mode=0620",
-            "gid=5"
-        ]
-    },
-    {
-        "destination": Path("/dev/shm"),
-        "type": "tmpfs",
-        "source": "shm",
-        "flags": MS_NOSUID | MS_NOEXEC | MS_NODEV,
-        "options": [
+            "gid=5",
+        ],
+    ),
+    Mount(
+        destination=Path("/dev/shm"),
+        type="tmpfs",
+        source="shm",
+        flags=MS_NOSUID | MS_NOEXEC | MS_NODEV,
+        options=[
             "mode=1777",
-            "size=65536k"
-        ]
-    },
-    {
-        "destination": Path("/dev/mqueue"),
-        "type": "mqueue",
-        "source": "mqueue",
-        "flags": MS_NOSUID | MS_NOEXEC | MS_NODEV,
-    },
-    {
-        "destination": Path("/sys"),
-        "type": "sysfs",
-        "source": "sysfs",
-        "flags": MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_RDONLY,
-    },
-    {
-        "destination": Path("/run"),
-        "type": "tmpfs",
-        "source": "shm",
-        "flags": MS_NOSUID | MS_NOEXEC | MS_NODEV,
-        "options": [
+            "size=65536k",
+        ],
+    ),
+    Mount(
+        destination=Path("/dev/mqueue"),
+        type="mqueue",
+        source="mqueue",
+        flags=MS_NOSUID | MS_NOEXEC | MS_NODEV,
+        options=None,
+    ),
+    Mount(
+        destination=Path("/sys"),
+        type="sysfs",
+        source="sysfs",
+        flags=MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_RDONLY,
+        options=None,
+    ),
+    Mount(
+        destination=Path("/run"),
+        type="tmpfs",
+        source="shm",
+        flags=MS_NOSUID | MS_NOEXEC | MS_NODEV,
+        options=[
             "mode=1777",
-            "size=65536k"
-        ]
-    },
+            "size=65536k",
+        ],
+    ),
 ]
 
 CONTAINER_DEVICE_NODES = [
-    {
-        "name": "null",
-        "major": 1,
-        "minor": 3,
-    },
-    {
-        "name": "zero",
-        "major": 1,
-        "minor": 5,
-    },
-    {
-        "name": "full",
-        "major": 1,
-        "minor": 7,
-    },
-    {
-        "name": "tty",
-        "major": 5,
-        "minor": 0,
-    },
-    {
-        "name": "random",
-        "major": 1,
-        "minor": 8,
-    },
-    {
-        "name": "urandom",
-        "major": 1,
-        "minor": 9,
-    },
+    DeviceNode(
+        name="null",
+        major=1,
+        minor=3,
+    ),
+    DeviceNode(
+        name="zero",
+        major=1,
+        minor=5,
+    ),
+    DeviceNode(
+        name="full",
+        major=1,
+        minor=7,
+    ),
+    DeviceNode(
+        name="tty",
+        major=5,
+        minor=0,
+    ),
+    DeviceNode(
+        name="random",
+        major=1,
+        minor=8,
+    ),
+    DeviceNode(
+        name="urandom",
+        major=1,
+        minor=9,
+    ),
 ]

--- a/furnace/config.py
+++ b/furnace/config.py
@@ -26,6 +26,7 @@ from .libc import CLONE_NEWPID, CLONE_NEWCGROUP, CLONE_NEWIPC, CLONE_NEWUTS, CLO
 
 Mount = namedtuple('Mount', ['destination', 'type', 'source', 'flags', 'options'])
 DeviceNode = namedtuple('DeviceNode', ['name', 'major', 'minor'])
+BindMount = namedtuple('BindMount', ['source', 'destination', 'readonly'])
 
 
 HOSTNAME = 'localhost'
@@ -135,5 +136,13 @@ CONTAINER_DEVICE_NODES = [
         name="urandom",
         major=1,
         minor=9,
+    ),
+]
+
+HOST_NETWORK_BIND_MOUNTS = [
+    BindMount(
+        source=Path('/etc/resolv.conf'),            # absolute path on host machine
+        destination=Path('etc', 'resolv.conf'),     # relative path in container
+        readonly=True,
     ),
 ]

--- a/furnace/context.py
+++ b/furnace/context.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Furnace.  If not, see <http://www.gnu.org/licenses/>.
 #
-
+import contextlib
 import json
 import logging
 import os
@@ -24,12 +24,12 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Union
+from typing import Union, List
 
 from . import pid1
-from .config import NAMESPACES
+from .config import NAMESPACES, HOST_NETWORK_BIND_MOUNTS, BindMount
 from .libc import unshare, setns, CLONE_NEWPID
-from .utils import PathEncoder
+from .utils import PathEncoder, BindMountContext
 
 logger = logging.getLogger(__name__)
 
@@ -152,20 +152,46 @@ class SetnsContext:
 
 
 class ContainerContext:
-    def __init__(self, root_dir: Union[str, Path], *, isolate_networking=False):
+    def __init__(self, root_dir: Union[str, Path], *, isolate_networking: bool=False, bind_mounts: List[BindMount]=None):
         if not isinstance(root_dir, Path):
             root_dir = Path(root_dir)
         self.root_dir = root_dir.resolve()
+        self.bind_mounts = bind_mounts
+        if self.bind_mounts is None:
+            self.bind_mounts = []
+        if not isolate_networking:
+           self.bind_mounts.extend(HOST_NETWORK_BIND_MOUNTS)
         self.pid1 = ContainerPID1Manager(root_dir, isolate_networking=isolate_networking)
         self.setns_context = None
+        self.bind_mount_contexts = None
+
+    def create_target(self, source, destination):
+        if source.is_file():
+            if destination.is_symlink():
+                destination.unlink()
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.touch()
+        else:
+            destination.mkdir(parents=True, exist_ok=True)
 
     def __enter__(self):
         self.pid1.start()
         self.setns_context = SetnsContext(self.pid1.pid)
+        self.bind_mount_contexts = contextlib.ExitStack()
+        for bind_mount in self.bind_mounts:
+            self.create_target(bind_mount.source, self.root_dir.joinpath(bind_mount.destination))
+            self.bind_mount_contexts.enter_context(BindMountContext(
+                bind_mount.source,
+                self.root_dir.joinpath(bind_mount.destination),
+                bind_mount.readonly
+            ))
         return self
 
     def __exit__(self, type, value, traceback):
         self.setns_context = None
+        if self.bind_mount_contexts:
+            self.bind_mount_contexts.__exit__(type, value, traceback)
+            self.bind_mount_contexts = None
         self.pid1.kill()
         return False
 

--- a/furnace/pid1.py
+++ b/furnace/pid1.py
@@ -64,17 +64,17 @@ class PID1:
     def mount_defaults(self):
         for m in CONTAINER_MOUNTS:
             options = None
-            if "options" in m:
-                options = ",".join(m["options"])
-            m["destination"].mkdir(parents=True, exist_ok=True)
-            mount(m["source"], m["destination"], m["type"], m.get("flags", 0), options)
+            if m.options:
+                options = ",".join(m.options)
+            m.destination.mkdir(parents=True, exist_ok=True)
+            mount(m.source, m.destination, m.type, m.flags, options)
 
     def create_tmpfs_dirs(self):
         if Path('/bin/systemd-tmpfiles').exists():
             for m in CONTAINER_MOUNTS:
-                if m["type"] == "tmpfs":
+                if m.type == "tmpfs":
                     tmpfiles_output = subprocess.check_output(
-                        ['/bin/systemd-tmpfiles', '--create', '--prefix', str(m["destination"])],
+                        ['/bin/systemd-tmpfiles', '--create', '--prefix', str(m.destination)],
                         stderr=subprocess.STDOUT,
                     )
                     if tmpfiles_output:
@@ -97,7 +97,7 @@ class PID1:
 
     def create_default_dev_nodes(self):
         for d in CONTAINER_DEVICE_NODES:
-            self.create_device_node(d["name"], d["major"], d["minor"], 0o666)
+            self.create_device_node(d.name, d.major, d.minor, 0o666)
 
     def create_loop_devices(self):
         self.create_device_node('loop-control', 10, 237, 0o660)

--- a/furnace/utils.py
+++ b/furnace/utils.py
@@ -22,7 +22,7 @@ import logging
 from json import JSONEncoder
 from pathlib import Path
 
-from .libc import mount, umount, umount2, MS_BIND, MNT_DETACH
+from .libc import mount, umount, umount2, MS_BIND, MNT_DETACH, MS_RDONLY
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +64,15 @@ class MountContext(abc.ABC):
 
 
 class BindMountContext(MountContext):
+    def __init__(self, source, destination, read_only=False):
+        super().__init__(source, destination)
+        self.read_only = read_only
+
     def get_mount_parameters(self):
-        return None, MS_BIND, None
+        flags = MS_BIND
+        if self.read_only:
+            flags |= MS_RDONLY
+        return None, flags, None
 
 
 class OverlayfsMountContext(MountContext):


### PR DESCRIPTION
With this solution the '/etc/resolv.conf' of the host can be used inside the container, because it is bind mounted before every run in host network mode (when network is not isolated).  The bind mount is read-only to avoid the modification of the '/etc/resolv.conf' of the host machine.