### PR TITLE
furnace/util.py: fix readonly bind-mount

### DIFF
--- a/furnace/utils.py
+++ b/furnace/utils.py
@@ -22,7 +22,7 @@ import logging
 from json import JSONEncoder
 from pathlib import Path
 
-from .libc import mount, umount, umount2, MS_BIND, MNT_DETACH, MS_RDONLY
+from .libc import mount, umount, umount2, MS_BIND, MNT_DETACH, MS_REMOUNT, MS_RDONLY
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +69,12 @@ class BindMountContext(MountContext):
         self.read_only = read_only
 
     def get_mount_parameters(self):
-        flags = MS_BIND
+        return None, MS_BIND, None
+
+    def mount(self):
+        super().mount()
         if self.read_only:
-            flags |= MS_RDONLY
-        return None, flags, None
+            mount(Path(), self.destination, None, MS_REMOUNT | MS_BIND | MS_RDONLY, None)
 
 
 class OverlayfsMountContext(MountContext):

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -160,6 +160,10 @@ def test_using_container_with_host_network(rootfs_for_testing, tmpdir_factory):
     host_resolvconf_content = Path('/etc/resolv.conf').read_bytes()
     with ContainerContext(rootfs_for_testing) as cnt:
         cnt.run(["/bin/ls", "/"], check=True)
+
+        with pytest.raises(OSError, message="'/etc/resolv.conf' should be mounted readonly"):
+            rootfs_for_testing.joinpath('etc', 'resolv.conf').touch()
+
         container_resolvconf_content = rootfs_for_testing.joinpath('etc', 'resolv.conf').read_bytes()
 
     assert host_resolvconf_content == container_resolvconf_content, \


### PR DESCRIPTION
"The remaining bits in the mountflags argument are also ignored, with
the exception of MS_REC."
Source: http://man7.org/linux/man-pages/man2/mount.2.html

That means the MS_RDONLY flag is also ignored at the time of the bind
mount. To solve this problem, the bind mounted path should be remounted
readonly.

"Since Linux 2.6.26, this flag can be used with MS_BIND to modify only
the per-mount-point flags.  This is particularly useful for setting
or clearing the "read-only" flag on a mount point without changing
the underlying filesystem.  Specifying mountflags as:

    MS_REMOUNT | MS_BIND | MS_RDONLY

will make access through this mountpoint read-only, without affecting
other mount points."
Source: http://man7.org/linux/man-pages/man2/mount.2.html