### PR TITLE
pid1: fix python3 pathlib issue

### DIFF
--- a/furnace/pid1.py
+++ b/furnace/pid1.py
@@ -185,7 +185,7 @@ class PID1:
     # NOTE: use only before create_namespaces()
     def get_loop_devices(self):
         for loop_path in Path('/dev').glob('loop[0-9]*'):
-            major, minor = divmod(os.stat(loop_path).st_rdev, 256)
+            major, minor = divmod(os.stat(str(loop_path)).st_rdev, 256)
             if major == 7:  # it's a loop device
                 yield DeviceNode(name=loop_path.name, major=major, minor=minor)
 


### PR DESCRIPTION
In python3.5 the os.stat() can't handle pathlib.Path.