### PR TITLE
.github/workflows/release.yml: add release process

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,30 @@
+name: bump version
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install make
+    - name: Bump version
+      run: "echo furnace_version=$(make bump-version) | tee --append $GITHUB_ENV"
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: "Bump version to ${{ env.furnace_version }}"
+        title: "Bump version to ${{ env.furnace_version }}"
+        body:
+        branch: "bump-version-to-v${{ env.furnace_version }}"
+        delete-branch: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip wheel twine
+        sudo apt update
+        sudo apt install debootstrap python3-venv make
+    - name: Make dists
+      run:
+        make release
+    - name: Release test
+      run:
+        make release-test
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true
+    - name: Read version
+      run: "echo furnace_version=$(cat furnace/VERSION) | tee --append $GITHUB_ENV"
+    - name: Tag
+      uses: negz/create-tag@v1
+      with:
+        version: "v${{ env.furnace_version }}"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ celerybeat-schedule
 
 # virtualenv
 .venv
+.release-venv
 venv/
 ENV/
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 .PHONY: autocs cs check check_copyright install dev clean doc
 
 VIRTUALENV ?= .venv
+RELEASE_VIRTUALENV ?= .release-venv
 PYCODESTYLE ?= $(VIRTUALENV)/bin/python3 -m pycodestyle
 AUTOPEP8 ?= $(VIRTUALENV)/bin/python3 -m autopep8
 FLAKE8 ?= $(VIRTUALENV)/bin/python3 -m flake8
@@ -44,7 +45,7 @@ check-copyright:
 	test/check_copyright_headers.py
 
 # Update requirements files for setup.py
-update-requirements: $(VIRTUALENV)/bin/python3
+update-requirements: virtualenv
 	$(VIRTUALENV)/bin/pip3 install --upgrade pip-tools
 	$(VIRTUALENV)/bin/pip-compile --no-emit-trusted-host --no-emit-index-url --upgrade --output-file requirements-dev.txt requirements-dev.in
 
@@ -53,25 +54,46 @@ update-requirements: $(VIRTUALENV)/bin/python3
 check: check-copyright dev
 	sudo PYTHONDONTWRITEBYTECODE=1 $(VIRTUALENV)/bin/pytest
 
-# Create a virtualenv in .venv or the directory given in the following form: 'make VIRTUALENV=.venv2 install'
-$(VIRTUALENV)/bin/python3:
+# Create a virtualenv in .virtualenv or the directory given in the following form: 'make virtualenv VIRTUALENV=.venv2 install'
+.PHONY: virtualenv
+virtualenv:
 	python3 -m venv $(VIRTUALENV)
 	$(VIRTUALENV)/bin/pip install --upgrade pip
 
+# Create a virtualenv in .release-virtualenv or the directory given in the
+# following form: 'make release-virtualenv RELEASE_VIRTUALENV=.release-venv2 install'
+.PHONY: release-virtualenv
+release-virtualenv:
+	python3 -m venv $(RELEASE_VIRTUALENV)
+	$(RELEASE_VIRTUALENV)/bin/pip install --upgrade pip
+
+.PHONY: release
+release: release-virtualenv
+	$(RELEASE_VIRTUALENV)/bin/pip3 install wheel
+	$(RELEASE_VIRTUALENV)/bin/python3 setup.py sdist bdist_wheel
+	$(RELEASE_VIRTUALENV)/bin/pip install dist/*.whl
+	$(RELEASE_VIRTUALENV)/bin/pip3 install -r requirements-dev.txt
+
+.PHONY: release-test
+release-test: release
+	sudo PYTHONDONTWRITEBYTECODE=1 $(RELEASE_VIRTUALENV)/bin/pytest
+
 # Install development dependencies (for testing) in virtualenv
-dev: $(VIRTUALENV)/bin/python3
+dev: virtualenv
 	$(VIRTUALENV)/bin/pip3 install --editable '.[dev]'
 
 # Clean directory and delete virtualenv
 clean:
-	$(VIRTUALENV)/bin/python3 setup.py clean --all
+	-$(VIRTUALENV)/bin/python3 setup.py clean --all
+	-$(RELEASE_VIRTUALENV)/bin/python3 setup.py clean --all
 	rm -rf $(VIRTUALENV)
+	rm -rf $(RELEASE_VIRTUALENV)
 
 get-version:
 	cat furnace/VERSION
 
 bump-version:
-	./bump_version.py
+	@./bump_version.py
 
 generate-badge:
 	$(VIRTUALENV)/bin/anybadge --value='3.6 | 3.7 | 3.8 | 3.9 | 3.10' --label python --file python-support.svg --overwrite


### PR DESCRIPTION
Github actions cannot push a protected branch, that is why the release
process splited two parts.
The first part is the 'version bump' workflow, bumps the version and
create a pull a request.
After that an administrator should perform a 'rebase and merge' for
this pull request.
The second part is the 'release' workflow, creates a wheel, performs
a relase testing, publishes the package to PYPI, and creates a tag
from the actual version.